### PR TITLE
refactor: simplify installation by removing Telegram token from provisioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,6 @@ resource "linode_instance" "continuo" {
     new_relic_license_key = var.new_relic_license_key
     new_relic_account_id  = var.new_relic_account_id
     new_relic_region      = var.new_relic_region
-    telegram_bot_token    = var.telegram_bot_token
   }
 
   # Wait for SSH and StackScript to complete

--- a/scripts/stackscript.sh
+++ b/scripts/stackscript.sh
@@ -15,7 +15,6 @@ export DEBIAN_FRONTEND=noninteractive
 # <UDF name="new_relic_license_key" label="New Relic License Key" default="" />
 # <UDF name="new_relic_account_id" label="New Relic Account ID" default="" />
 # <UDF name="new_relic_region" label="New Relic Region" default="US" />
-# <UDF name="telegram_bot_token" label="Telegram Bot Token" default="" />
 
 ADMIN_USER="$ADMIN_USERNAME"
 SERVER_HOSTNAME="$HOSTNAME"
@@ -155,12 +154,6 @@ su - "$ADMIN_USER" -c "mkdir -p ~/.openclaw/workspace"
 # Create OpenClaw config with local gateway mode and generated token
 GATEWAY_TOKEN=$(openssl rand -hex 32)
 jq -n --arg token "$GATEWAY_TOKEN" '{gateway: {mode: "local", auth: {token: $token}}}' > /home/$ADMIN_USER/.openclaw/openclaw.json
-
-# Add Telegram channel if token is provided
-if [ -n "${TELEGRAM_BOT_TOKEN}" ]; then
-  jq --arg tg_token "$TELEGRAM_BOT_TOKEN" '.channels.telegram = {enabled: true, botToken: $tg_token, dmPolicy: "pairing"}' \
-    /home/$ADMIN_USER/.openclaw/openclaw.json > /tmp/openclaw.json && mv /tmp/openclaw.json /home/$ADMIN_USER/.openclaw/openclaw.json
-fi
 
 chown $ADMIN_USER:$ADMIN_USER /home/$ADMIN_USER/.openclaw/openclaw.json
 

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -20,9 +20,6 @@ ssh_public_keys = [
 # Path to SSH private key (needed for provisioners to upload files)
 # ssh_private_key_path = "~/.ssh/id_ed25519"
 
-# Telegram bot token (get from @BotFather)
-# telegram_bot_token = "123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
-
 # Linode instance configuration (optional)
 # region = "us-ord"           # Chicago region (default)
 # instance_type = "g6-standard-2"  # 2GB instance (default)

--- a/variables.tf
+++ b/variables.tf
@@ -46,13 +46,6 @@ variable "hostname" {
   default     = "continuo"
 }
 
-variable "telegram_bot_token" {
-  description = "Telegram bot token for OpenClaw"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-
 variable "region" {
   description = "Linode region for the instance"
   type        = string


### PR DESCRIPTION
## Summary

Simplifies the initial VM provisioning by removing Telegram bot token configuration from Terraform and StackScript.

## Changes

- Removed `telegram_bot_token` variable from `variables.tf`
- Removed Telegram token from StackScript UDF parameters
- Removed automatic Telegram channel configuration in `stackscript.sh`
- Updated `terraform.tfvars.example` to remove Telegram token placeholder

## Motivation

1. **Fewer secrets during provisioning** - The Telegram bot token is sensitive and shouldn't need to be passed through Terraform
2. **Simpler initial setup** - New VMs start with a minimal OpenClaw config; channels can be configured post-install
3. **Better security posture** - Tokens are configured directly on the VM rather than through provisioning tools
4. **Flexibility** - Users can choose to configure Telegram (or other channels) after the VM is up

## Post-Install Configuration

After provisioning, configure Telegram manually:
```bash
openclaw config set channels.telegram.enabled true
openclaw config set channels.telegram.botToken "YOUR_TOKEN"
openclaw config set channels.telegram.dmPolicy pairing
openclaw gateway restart
```

Or edit `~/.openclaw/openclaw.json` directly.