### PR TITLE
feat: add hackernews skill for top HN posts

### DIFF
--- a/skills_scripts/hackernews/hackernews.sh
+++ b/skills_scripts/hackernews/hackernews.sh
@@ -35,7 +35,7 @@ if [ "$FETCH_COUNT" -gt 100 ]; then
     FETCH_COUNT=100
 fi
 
-API_URL="https://hn.algolia.com/api/v1/search?tags=story&numericFilters=created_at_i>${TIMESTAMP}&hitsPerPage=${FETCH_COUNT}"
+API_URL="https://hn.algolia.com/api/v1/search?tags=story&numericFilters=created_at_i%3E${TIMESTAMP}&hitsPerPage=${FETCH_COUNT}"
 
 # Faz request e formata saída
 curl -s "$API_URL" | jq -r --argjson count "$COUNT" '


### PR DESCRIPTION
## 🔶 Hacker News Skill

Skill para buscar e formatar os posts mais populares do Hacker News.

### Funcionalidades

- ✅ Busca top posts por período (dia, semana, mês)
- ✅ Ordenação por pontos/upvotes
- ✅ Formatação limpa para leitura
- ✅ Suporte a contexto automático
- ✅ Sem necessidade de API key (usa Algolia HN API)

### Arquivos

- `skills_scripts/hackernews/SKILL.md` - Instruções detalhadas para o agente
- `skills_scripts/hackernews/README.md` - Documentação
- `skills_scripts/hackernews/hackernews.sh` - Script bash para query direta

### Exemplo de Uso

```
"Top 5 posts do Hacker News de hoje"
"O que bombou no HN essa semana?"
```

### Formato de Saída

```
#1 Título do Post - 500 pontos
   🔗 https://link.com
   📝 Breve descrição do conteúdo
```

### Caso de Uso: Cron Diário

Receber top 3 links mais populares do dia anterior às 09:00 UTC.